### PR TITLE
added except ZeroDivisionError to product.average_rating

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,7 +62,11 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        try:
+            avg = total_rating / len(ratings)
+        except ZeroDivisionError as ex:
+            avg = 0
+
         return avg
 
     class Meta:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- added an exception handler for zero division in `bangazonapi/models/product.py`, specifically the `average_rating` property of the `Product` model.

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
	- you may still get an Assertion Error from `payments`
- [ ] Seed database
- [ ] Request one product
- [ ] Request many products


## Related Issues

- Fixes #15
