### PR TITLE
fixed expiration and creation date assignments being flipped in Payments create view

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- corrected the assignments to `new_payment.create_date` and `...expiration_date` that were flipped in `bangazonapi/views/paymenttype.py`

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
	- everything should pass
- [ ] Seed database


## Related Issues

- Fixes #19
