### PR TITLE
Fixed PaymentTypes list returning data from other users

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -79,12 +79,9 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
-
-        customer_id = self.request.query_params.get('customer', None)
-
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        auth_customer = Customer.objects.get(user=request.auth.user)
+        payment_types = Payment.objects.filter(
+            customer__id=auth_customer.user.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,7 +81,7 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         auth_customer = Customer.objects.get(user=request.auth.user)
         payment_types = Payment.objects.filter(
-            customer__id=auth_customer.user.id)
+            customer__id=auth_customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
Changed the `list` method on the payment type ViewSet to use the authenticated user to filter down the correct results of a GET to `/paymenttypes`

## Changes

- In `bangazonapi/views/paymenttype.py`:
	- Added ORM call to get the authenticated customer
	- Changed `Payment.objects.all` to `.filter` using the id of the authenticated customer
	- Got rid of the extraneous(?) param filter


## Testing

Description of how to test code...

- [ ] Run migrations and seed database
	- use `./seed_data.sh` from project root
- [ ] Run test suite
	- use `python3 manage.py test` from project root
- [ ] GET `/paymenttypes` and ensure that all results belong to the authenticated user
	- by default, the Postman "Get All Payment Types" request will use user `5` who has one payment type

## Related Issues

- Fixes #18
