### PR TITLE
Fixed not being able to delete from cart via /lineitems

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -80,7 +80,8 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(
-                product__id=pk, order__customer=customer)
+                pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -18,6 +18,7 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
         )
         fields = ('id', 'url', 'order', 'product')
 
+
 class LineItems(ViewSet):
     """Line items for Bangazon orders"""
 
@@ -51,9 +52,11 @@ class LineItems(ViewSet):
         try:
             # line_item = OrderProduct.objects.get(pk=pk)
             customer = Customer.objects.get(user=request.auth.user)
-            line_item = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            line_item = OrderProduct.objects.get(
+                pk=pk, order__customer=customer)
 
-            serializer = LineItemSerializer(line_item, context={'request': request})
+            serializer = LineItemSerializer(
+                line_item, context={'request': request})
 
             return Response(serializer.data)
 
@@ -76,7 +79,8 @@ class LineItems(ViewSet):
         """
         try:
             customer = Customer.objects.get(user=request.auth.user)
-            order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product = OrderProduct.objects.get(
+                product__id=pk, order__customer=customer)
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Deleting things from the cart by issuing a DELETE to `/lineitems/:id`.

## Changes

- Changed `pk=pk` to `product__id=pk` in `OrderProduct.objects.get` in the `destroy` method of the `LineItems` ViewSet

## Testing

- [ ] Run migrations and seed database
	- use `./seed_data.sh` from project root
- [ ] Run test suite
	- use `python3 manage.py test` from project root
- [ ] Try deleting a product from your cart via `/lineitems/:id`


## Related Issues

- Fixes #20
