### PR TITLE
Fixed /profile/cart returning lineitems AND line_items

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -82,7 +82,8 @@ class Profile(ViewSet):
         """
         try:
             current_user = Customer.objects.get(user=4)
-            current_user.recommends = Recommendation.objects.filter(recommender=current_user)
+            current_user.recommends = Recommendation.objects.filter(
+                recommender=current_user)
 
             serializer = ProfileSerializer(
                 current_user, many=False, context={'request': request})
@@ -178,14 +179,11 @@ class Profile(ViewSet):
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
-                                                'request': request}).data
-                cart["order"]["line_items"] = line_items.data
-                cart["order"]["size"] = len(line_items.data)
+                    'request': request}).data
+                cart["order"]["size"] = len(line_items)
 
             except Order.DoesNotExist as ex:
                 return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
In the special `cart` endpoint of the profile ViewSet we were originally manually serializing the line_items separately from serializing orders. However, orders already provide the line items serialized as "lineitems". There is still an ORM call to OrderProducts in order to provide an order size. Size implementation is still the same -- it is the number of unique products in the cart, not the total number of products in the cart.

## Changes

- In `bangazonapi/views/profile.py` `cart` GET view:
	- removed use of LineItemSerializer
	- lineitems are added to the response via the imported OrderSerializer

## Testing

Description of how to test code...

- [ ] Run migrations and seed database
	- use `./seed_data.sh` from project root
- [ ] Run test suite
	- use `python3 manage.py test` from project root
- [ ] GET `/profile/cart` as a user with a cart (Postman has a builtin for user 5)
	- verify that there is only `lineitems` and no `line_items`

## Related Issues

- Fixes #24
