### PR TITLE
Fixed /profile always returning user 4

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,8 +81,9 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=4)
-            current_user.recommends = Recommendation.objects.filter(recommender=current_user)
+            current_user = Customer.objects.get(user=request.auth.user)
+            current_user.recommends = Recommendation.objects.filter(
+                recommender=current_user)
 
             serializer = ProfileSerializer(
                 current_user, many=False, context={'request': request})
@@ -178,14 +179,11 @@ class Profile(ViewSet):
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
-                                                'request': request}).data
-                cart["order"]["line_items"] = line_items.data
-                cart["order"]["size"] = len(line_items.data)
+                    'request': request}).data
+                cart["order"]["size"] = len(line_items)
 
             except Order.DoesNotExist as ex:
                 return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
The profile ViewSet had a hardcoded user id in it's ORM call to get the proper customer. It is now using the token from the request authorization header.

## Changes

- Replaced `user=4` with `user=request.auth.user` in `bangazonapi/views/profile.py` `Profile.list`

## Testing

- [ ] Run migrations and seed database
	- use `./seed_data.sh` from project root
- [ ] Run test suite
	- use `python3 manage.py test` from project root
- [ ] Pick a user other than user 4 (Postman defaults to user 5) and GET your `/profile`
	- confirm that you get the correct profile


## Related Issues

- Fixes #22
