### PR TITLE
FIX products being posted to closed orders

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -24,6 +24,7 @@ class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('id', 'product')
         depth = 1
 
+
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
@@ -35,7 +36,8 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             view_name='order',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
+        fields = ('id', 'url', 'created_date',
+                  'payment_type', 'customer', 'lineitems')
 
 
 class Orders(ViewSet):
@@ -104,7 +106,8 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = Payment.objects.get(
+            pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -238,7 +238,6 @@ class Profile(ViewSet):
             try:
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
-                print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()
                 open_order.created_date = datetime.datetime.now()

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -204,6 +204,12 @@ class Profile(ViewSet):
             @apiHeaderExample {String} Authorization
                 Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
+            @apiParam {id} product_id Product Id to add product to current order
+            @apiParamExample {json} Input
+                {
+                    "product_id": 35
+                }
+
             @apiSuccess (200) {Object} line_item Line items in cart
             @apiSuccess (200) {Number} line_item.id Line item id
             @apiSuccess (200) {Object} line_item.product Product in cart

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -236,7 +236,8 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(
+                    customer=current_user, payment_type=None)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
This fix enables customers to properly create/add to/complete orders by ensuring that the cart is always grabbing the current customer's only order with **no** payment set yet.

I think it'd be worth thinking about encapsulating the logic for finding the current open order for any given customer.

## Changes

- In `bangazonapi/views/order.py`, `update` view
	- update order now looks up `payment_type` by `pk`
- In `bangazonapi/views/profile.py`, `POST` to custom action `cart`
	- added example to api docstring 
	- removed extranous print
	- changed `open_order` ORM call to require `payment=None`

## Testing

- [ ] Run migrations and seed database
	- use `./seed_data.sh` from project root
- [ ] Run test suite
	- use `python3 manage.py test` from project root
- [ ] Pick a token for the rest of the process
	- it is easier to pick a user with a valid payment type
	- I used Jisie's token: 9ba45f09651c5b0c404f37a2d2572c026c146688
- [ ] Add something to your cart
	- `POST` to `/profile/cart`:
	```json
	{
		"product_id": 35
	}
	```
- [ ] Verify that it is in your cart
	- `GET` to `/profile/cart`
	- save the `url` field for later
- [ ] Grab your `payment_type` id
	- `GET` to `/payment_types`
- [ ] Complete the order
	- `PUT` to the `url` from the cart:
	```json
	{
		"payment_type": 3
	}
	```
- [ ] `GET` your cart to confirm it's empty
	- look for a `404`
- [ ] `POST` something to the cart
- [ ] `GET` your cart to confirm the product is there


## Related Issues

- Fixes #23
