### PR TITLE
bumped max product price from 10k to 17.5k

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -15,7 +15,7 @@ class Product(SafeDeleteModel):
     customer = models.ForeignKey(
         Customer, on_delete=models.DO_NOTHING, related_name='products')
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],)
     description = models.CharField(max_length=255,)
     quantity = models.IntegerField(validators=[MinValueValidator(0)],)
     created_date = models.DateField(auto_now_add=True)


### PR DESCRIPTION
According to Issue #16, the max price should be 17.5 thousand dollars. However, upon testing that change it doesn't seem that the system **is** rejecting products that exceed that validation.

I have created a new issue.

## Changes

- In `bangazonapi/models/product.py`
	- Updated `Product.price` `MaxValueValidator` to `17500.00`

## Testing

- [ ] Run migrations and seed database
	- use `./seed_data.sh` from project root
- [ ] Run test suite
	- use `python3 manage.py test` from project root
- [ ] Create a product with a price between `10000.00` and `17500.00`
	- I used the `Create product (JSON body)` Postman request
	- Verify that it succeeds


## Related Issues

- Fixes #16
